### PR TITLE
Index: store file names instead of file paths under the "items" key in index.json

### DIFF
--- a/src/snapshot_test.go
+++ b/src/snapshot_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	cryptoRand "crypto/rand"
@@ -59,9 +60,9 @@ func TestCreateSnapshot(t *testing.T) {
 	resources := make(map[string][]MigrateDataRequestItemDTO)
 
 	// Using the index, read each data file and group the contents by resource type (e.g. dashboards).
-	for resourceType, filePaths := range index.Items {
-		for _, filePath := range filePaths {
-			file, err := os.Open(filePath)
+	for resourceType, fileNames := range index.Items {
+		for _, fileName := range fileNames {
+			file, err := os.Open(filepath.Join(writer.folder, fileName))
 			require.NoError(t, err)
 
 			snapshotReader := NewSnapshotReader(contracts.AssymetricKeys{


### PR DESCRIPTION
Given that the presigned url returned by gms expects the file name to have this prefix: 
```go
startsWithKey := fmt.Sprintf("%s/snapshots/%s", stackID, snapshotID)
```
let's store just the file names instead of the file paths to make it easier to build the file key later. 

We also know the folder where the files are stored so there's no need to include the whole file path in the index.

`index.json` will look like this from now on:
```json
{
  "checksum": "4162d87cf8cf7890aacf5861927005301c890ec03035a00ac5803e8c9b8e6726",
  "version": 1,
  "encryptionAlgo": "nacl",
  "publicKey": "6iMhjfP61nr6mzxi5Nu5cU4CyB+FvatSieVGtqd0SRc=",
  "items": {
    "DASHBOARD": [
      "dashboard_partition_0.json"
    ],
    "DATASOURCE": [
      "datasource_partition_0.json"
    ],
    "FOLDER": [
      "folder_partition_0.json"
    ]
  }
}
```

instead of
```json
{
  "checksum": "4162d87cf8cf7890aacf5861927005301c890ec03035a00ac5803e8c9b8e6726",
  "version": 1,
  "encryptionAlgo": "nacl",
  "publicKey": "6iMhjfP61nr6mzxi5Nu5cU4CyB+FvatSieVGtqd0SRc=",
  "items": {
    "DASHBOARD": [
      "{folder}/dashboard_partition_0.json"
    ],
    "DATASOURCE": [
      "{folder}/datasource_partition_0.json"
    ],
    "FOLDER": [
      "{folder}/folder_partition_0.json"
    ]
  }
}
```