### PR TITLE
snapshot: remove need for sync folder

### DIFF
--- a/src/snapshot.go
+++ b/src/snapshot.go
@@ -66,18 +66,6 @@ func NewSnapshotWriter(keys contracts.AssymetricKeys, crypto contracts.Crypto, f
 		if err := os.MkdirAll(folder, 0750); err != nil {
 			return nil, fmt.Errorf("creating directory to store snapshot files: %w", err)
 		}
-		folderFile, err := os.Open(folder)
-		if err != nil {
-			return nil, fmt.Errorf("opening directory: path=%s %w", folder, err)
-		}
-		defer func() {
-			if closeErr := folderFile.Close(); closeErr != nil {
-				err = errors.Join(err, fmt.Errorf("closing folder file: path=%s %w", folder, closeErr))
-			}
-		}()
-		if err := folderFile.Sync(); err != nil {
-			return nil, fmt.Errorf("syncinf folder: path=%s %w", folder, err)
-		}
 	}
 
 	return &SnapshotWriter{


### PR DESCRIPTION
This step is not necessary and it was breaking snapshot creation on Windows.

Re-tested e2e migration in macOS (Sonoma/14), Windows 11 and Linux (Ubuntu 24.04).

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/944