### PR TITLE
Revert "replace sha256 with crc32"

### DIFF
--- a/src/snapshot.go
+++ b/src/snapshot.go
@@ -3,11 +3,11 @@ package snapshot
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"os"
 	"path/filepath"
@@ -202,7 +202,7 @@ type partition struct {
 }
 
 func computeBufferChecksum(buffer []byte) (string, error) {
-	hash := crc32.NewIEEE()
+	hash := sha256.New()
 	bytesWritten, err := hash.Write(buffer)
 	if err != nil {
 		return "", fmt.Errorf("writing buffer to hash :%w", err)
@@ -214,7 +214,7 @@ func computeBufferChecksum(buffer []byte) (string, error) {
 }
 
 func computeIndexChecksum(index *Index) (string, error) {
-	hash := crc32.NewIEEE()
+	hash := sha256.New()
 	if err := binary.Write(hash, binary.LittleEndian, index.Version); err != nil {
 		return "", fmt.Errorf("writing index version to hash: %w", err)
 	}


### PR DESCRIPTION
We forgot to update create a new release for this repo and update grafana to use the new version, for that reason we can't change the hash function without breaking already existing snapshots.

Reverts grafana/grafana-cloud-migration-snapshot#8