### PR TITLE
snapshot: add 'LIBRARY_ELEMENT' data type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/grafana/grafana-cloud-migration-snapshot
 go 1.22.2
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/src/snapshot.go
+++ b/src/snapshot.go
@@ -20,9 +20,10 @@ import (
 type MigrateDataType string
 
 const (
-	DashboardDataType  MigrateDataType = "DASHBOARD"
-	DatasourceDataType MigrateDataType = "DATASOURCE"
-	FolderDataType     MigrateDataType = "FOLDER"
+	DashboardDataType      MigrateDataType = "DASHBOARD"
+	DatasourceDataType     MigrateDataType = "DATASOURCE"
+	FolderDataType         MigrateDataType = "FOLDER"
+	LibraryElementDataType MigrateDataType = "LIBRARY_ELEMENT"
 )
 
 type MigrateDataRequestItemDTO struct {

--- a/src/snapshot_test.go
+++ b/src/snapshot_test.go
@@ -9,7 +9,6 @@ import (
 
 	cryptoRand "crypto/rand"
 
-	"github.com/google/uuid"
 	"github.com/grafana/grafana-cloud-migration-snapshot/src/contracts"
 	"github.com/grafana/grafana-cloud-migration-snapshot/src/infra/crypto"
 	"github.com/stretchr/testify/assert"
@@ -17,8 +16,10 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
-func tempDir() string {
-	return filepath.Join(os.TempDir(), "grafana-cloud-migration-snapshot", uuid.NewString())
+func tempDir(t *testing.T) string {
+	t.Helper()
+
+	return filepath.Join(t.TempDir(), "grafana-cloud-migration-snapshot")
 }
 
 func TestCreateSnapshot(t *testing.T) {
@@ -37,7 +38,7 @@ func TestCreateSnapshot(t *testing.T) {
 		Private: senderPrivateKey[:],
 	},
 		nacl,
-		tempDir(),
+		tempDir(t),
 	)
 	require.NoError(t, err)
 
@@ -105,7 +106,7 @@ func TestChecksumIsValidated(t *testing.T) {
 	t.Run("data file checksum is validated", func(t *testing.T) {
 		t.Parallel()
 
-		dir := tempDir()
+		dir := tempDir(t)
 
 		writer, err := NewSnapshotWriter(contracts.AssymetricKeys{
 			Public:  recipientPublicKey[:],
@@ -174,7 +175,7 @@ func TestChecksumIsValidated(t *testing.T) {
 			Private: senderPrivateKey[:],
 		},
 			nacl,
-			tempDir(),
+			tempDir(t),
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
In order to support migrating Library Elements, adding the type to the constants.

Also removing the need for `uuid` library by using `t.TempDir()` instead of `os.TempDir()`