### PR TITLE
add more resource types

### DIFF
--- a/src/snapshot.go
+++ b/src/snapshot.go
@@ -20,10 +20,15 @@ import (
 type MigrateDataType string
 
 const (
-	DashboardDataType      MigrateDataType = "DASHBOARD"
-	DatasourceDataType     MigrateDataType = "DATASOURCE"
-	FolderDataType         MigrateDataType = "FOLDER"
-	LibraryElementDataType MigrateDataType = "LIBRARY_ELEMENT"
+	DashboardDataType        MigrateDataType = "DASHBOARD"
+	DatasourceDataType       MigrateDataType = "DATASOURCE"
+	FolderDataType           MigrateDataType = "FOLDER"
+	LibraryElementDataType   MigrateDataType = "LIBRARY_ELEMENT"
+	AlertRuleType            MigrateDataType = "ALERT_RULE"
+	ContactPointType         MigrateDataType = "CONTACT_POINT"
+	NotificationPolicyType   MigrateDataType = "NOTIFICATION_POLICY"
+	NotificationTemplateType MigrateDataType = "NOTIFICATION_TEMPLATE"
+	MuteTimingType           MigrateDataType = "MUTE_TIMING"
 )
 
 type MigrateDataRequestItemDTO struct {


### PR DESCRIPTION
These constants are used by grafana when writing snapshots and and by GMS when reading snapshots.

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947