### PR TITLE
Snapshot: add plugin, annotation and report data types

### DIFF
--- a/src/snapshot.go
+++ b/src/snapshot.go
@@ -29,6 +29,9 @@ const (
 	NotificationPolicyType   MigrateDataType = "NOTIFICATION_POLICY"
 	NotificationTemplateType MigrateDataType = "NOTIFICATION_TEMPLATE"
 	MuteTimingType           MigrateDataType = "MUTE_TIMING"
+	PluginDataType           MigrateDataType = "PLUGIN"
+	AnnotationDataType       MigrateDataType = "ANNOTATION"
+	ReportDataType           MigrateDataType = "REPORT"
 )
 
 type MigrateDataRequestItemDTO struct {

--- a/src/snapshot_test.go
+++ b/src/snapshot_test.go
@@ -59,6 +59,9 @@ func TestCreateSnapshot(t *testing.T) {
 		NotificationPolicyType,
 		NotificationTemplateType,
 		MuteTimingType,
+		PluginDataType,
+		AnnotationDataType,
+		ReportDataType,
 	} {
 		resources = append(resources, input{
 			resourceType: resourceType,


### PR DESCRIPTION
Adding the types to the constants in order to support migrating plugins, annotations and reports.

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1036