### PR TITLE
Crypto: Add support for HPKE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,15 @@
 module github.com/grafana/grafana-cloud-migration-snapshot
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/crypto v0.50.0
+	golang.org/x/crypto v0.51.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
-golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/src/infra/crypto/hpke.go
+++ b/src/infra/crypto/hpke.go
@@ -1,0 +1,86 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/hpke"
+	"fmt"
+	"io"
+
+	"github.com/grafana/grafana-cloud-migration-snapshot/src/contracts"
+)
+
+type Hpke struct{}
+
+var _ contracts.Crypto = (*Hpke)(nil)
+
+func NewHpke() Hpke {
+	return Hpke{}
+}
+
+func (Hpke) Algo() string {
+	return "hpke-p521-shake256-aes256gcm"
+}
+
+func (h Hpke) Encrypt(keys contracts.AssymetricKeys, reader io.Reader) (io.Reader, error) {
+	msg, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading payload from reader: %w", err)
+	}
+
+	pk, err := h.kem().NewPublicKey(keys.Public)
+	if err != nil {
+		return nil, fmt.Errorf("creating ecdh public key: %w", err)
+	}
+
+	encrypted, err := hpke.Seal(pk, h.kdf(), h.aead(), []byte(h.Algo()), msg)
+	if err != nil {
+		return nil, fmt.Errorf("encrypting payload failed: %w", err)
+	}
+
+	return bytes.NewReader(encrypted), nil
+}
+
+func (h Hpke) Decrypt(keys contracts.AssymetricKeys, reader io.Reader) (io.Reader, error) {
+	encryptedPayload, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading from reader: %w", err)
+	}
+
+	sk, err := h.kem().NewPrivateKey(keys.Private)
+	if err != nil {
+		return nil, fmt.Errorf("creating ecdh private key: %w", err)
+	}
+
+	decrypted, err := hpke.Open(sk, h.kdf(), h.aead(), []byte(h.Algo()), encryptedPayload)
+	if err != nil {
+		return nil, fmt.Errorf("decrypting payload failed: %w", err)
+	}
+
+	return bytes.NewReader(decrypted), nil
+}
+
+func (h Hpke) GenerateKeys() (contracts.AssymetricKeys, error) {
+	privateKey, err := h.kem().GenerateKey()
+	if err != nil {
+		return contracts.AssymetricKeys{}, fmt.Errorf("generating private key: %w", err)
+	}
+
+	privateKeyBytes, err := privateKey.Bytes()
+	if err != nil {
+		return contracts.AssymetricKeys{}, fmt.Errorf("getting private key bytes: %w", err)
+	}
+
+	publicKey := privateKey.PublicKey()
+
+	return contracts.AssymetricKeys{
+		Public:  publicKey.Bytes(),
+		Private: privateKeyBytes,
+	}, nil
+}
+
+func (h Hpke) kem() hpke.KEM { return hpke.DHKEM(ecdh.P521()) }
+
+func (h Hpke) kdf() hpke.KDF { return hpke.SHAKE256() }
+
+func (h Hpke) aead() hpke.AEAD { return hpke.AES256GCM() }

--- a/src/infra/crypto/hpke.go
+++ b/src/infra/crypto/hpke.go
@@ -19,7 +19,7 @@ func NewHpke() Hpke {
 }
 
 func (Hpke) Algo() string {
-	return "hpke-p521-shake256-aes256gcm"
+	return "hpke-p521-hkdfsha512-aes256gcm"
 }
 
 func (h Hpke) Encrypt(keys contracts.AssymetricKeys, reader io.Reader) (io.Reader, error) {
@@ -81,6 +81,6 @@ func (h Hpke) GenerateKeys() (contracts.AssymetricKeys, error) {
 
 func (h Hpke) kem() hpke.KEM { return hpke.DHKEM(ecdh.P521()) }
 
-func (h Hpke) kdf() hpke.KDF { return hpke.SHAKE256() }
+func (h Hpke) kdf() hpke.KDF { return hpke.HKDFSHA512() }
 
 func (h Hpke) aead() hpke.AEAD { return hpke.AES256GCM() }

--- a/src/infra/crypto/hpke_test.go
+++ b/src/infra/crypto/hpke_test.go
@@ -1,0 +1,51 @@
+package crypto
+
+import (
+	cryptoRand "crypto/rand"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-cloud-migration-snapshot/src/contracts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHpke(t *testing.T) {
+	t.Parallel()
+
+	hpke := NewHpke()
+
+	sender, err := hpke.GenerateKeys()
+	require.NoError(t, err)
+
+	recipient, err := hpke.GenerateKeys()
+	require.NoError(t, err)
+
+	msg := "hello world"
+
+	var nonce [24]byte
+	_, err = io.ReadFull(cryptoRand.Reader, nonce[:])
+	require.NoError(t, err)
+
+	reader, err := hpke.Encrypt(contracts.AssymetricKeys{
+		Public:  recipient.Public,
+		Private: sender.Private,
+	},
+		strings.NewReader(msg),
+	)
+	require.NoError(t, err)
+
+	reader, err = hpke.Decrypt(contracts.AssymetricKeys{
+		Public:  sender.Public,
+		Private: recipient.Private,
+	},
+		reader,
+	)
+	require.NoError(t, err)
+
+	buffer, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg, string(buffer))
+}


### PR DESCRIPTION
This adds support for encrypting snapshots with hybrid public-key encryption (RFC 9180) using FIPS compliant building blocks:
- Key encapsulation mechanism (KEM) with Curve P-521;
- Key derivation function with SHA-512;
- AEAD with AES-256-GCM.